### PR TITLE
Fixed previewTooltip visibility duration bug

### DIFF
--- a/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
+++ b/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
@@ -2,6 +2,7 @@ import { PreviewTooltipItem } from '@root/lib/types';
 import { useAtomValue } from 'jotai';
 import styled from 'styled-components';
 import {
+  durationAtom,
   myScope,
   previewTooltipPositionAtom,
   previewTooltipStrAtom,
@@ -25,13 +26,15 @@ function PreviewTooltips({
   );
   const previewTooltipStr = useAtomValue(previewTooltipStrAtom, myScope);
   const videoValues = useAtomValue(valuesAtom, myScope);
+  const videoDuration = useAtomValue(durationAtom, myScope);
+
   return (
     <>
       {data.id === 'text' && (
         <TextTooltip
           backgroundColor={videoValues.controlsBar?.barColor}
           data-cy='textPreviewTooltip'
-          isVisible={isHovered || isProgressDragging}
+          isVisible={(isHovered || isProgressDragging) && videoDuration > 0}
           style={{
             transform: `translate(${previewTooltipPosition}px, -60px)`,
           }}


### PR DESCRIPTION
* When video duration is not set, the previewTooltip should not show as the time won't be correct