### PR TITLE
Added preview thumbnails

### DIFF
--- a/packages/custoplayer/cypress/e2e/VideoActions.cy.ts
+++ b/packages/custoplayer/cypress/e2e/VideoActions.cy.ts
@@ -112,8 +112,23 @@ describe('Video Actions', () => {
     cy.dataCy('HTMLVideoPlayer')
       .should('have.prop', 'currentTime')
       .then((x) => expect(x).to.be.greaterThan(2));
-    cy.dataCy('textPreviewTooltip').should('exist');
+    cy.dataCy('textPreviewTooltip').should('be.visible');
   });
+
+  it('changes current time of video to test previewTooltipThumbnail', () => {
+    cy.visit('/')
+    cy.dataCy("changePreviewTooltipIdButton").trigger("click")
+    cy.dataCy('videoPlayerWrapper').should('exist');
+    cy.dataCy('videoPlayerWrapper').trigger('mouseover');
+    cy.dataCy('progressBar1')
+      .trigger('mousedown')
+      .trigger('mousemove', { x: 20 });
+    cy.dataCy('imageThumbnailContainer').should('be.visible');
+    cy.dataCy('imageThumbnail').should('have.css', 'background-image', 'url("https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/thumbs.jpg")');
+    // The background position should have changed
+    cy.dataCy('imageThumbnail').should('have.css', 'background-position', "-875px -210px");
+  })
+
   it('changes quality of the video via settings button', () => {
     cy.visit('/');
     cy.dataCy('videoPlayerWrapper').should('exist');

--- a/packages/custoplayer/package.json
+++ b/packages/custoplayer/package.json
@@ -25,9 +25,9 @@
   ],
   "main": "./dist/custoplayer.umd.js",
   "module": "./dist/custoplayer.es.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/custoplayer.es.js",
       "require": "./dist/custoplayer.umd.js"
     }

--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -3,7 +3,7 @@ import Custoplayer from './lib/EntryPoint';
 import { useState } from 'react';
 
 function App() {
-  const [previewTooltipId, setPreviewTooltipId] = useState('text');
+  const [previewTooltipId, setPreviewTooltipId] = useState<'text' | 'thumbnail' | 'textAndThumbnail'>('text');
 
   return (
     <MainContainer>
@@ -128,6 +128,7 @@ function App() {
         >
           Change previewTooltip to thumbnail
         </button>
+
       </Wrapper>
     </MainContainer>
   );

--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -3,7 +3,9 @@ import Custoplayer from './lib/EntryPoint';
 import { useState } from 'react';
 
 function App() {
-  const [previewTooltipId, setPreviewTooltipId] = useState<'text' | 'thumbnail' | 'textAndThumbnail'>('text');
+  const [previewTooltipId, setPreviewTooltipId] = useState<
+    'text' | 'thumbnail' | 'textAndThumbnail'
+  >('text');
 
   return (
     <MainContainer>
@@ -128,7 +130,6 @@ function App() {
         >
           Change previewTooltip to thumbnail
         </button>
-
       </Wrapper>
     </MainContainer>
   );

--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -13,7 +13,9 @@ function App() {
           preload='auto'
           values={{
             previewTooltip: {
-              id: 'text',
+              id: 'thumbnail',
+              atlasImage:
+                'https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/thumbs.jpg',
             },
             controlsBar: {
               barColor: '#386641',
@@ -100,14 +102,20 @@ function App() {
             label='English'
             kind='metadata'
             src='https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/english.vtt'
-            default
             srcLang='en'
+            default
           />
           <track
             label='Spanish'
             kind='metadata'
             srcLang='es'
             src='https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/spanish.vtt'
+          />
+          <track
+            label='bob'
+            kind='metadata'
+            id='custoplayer-thumbnails'
+            src='https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/thumbs.vtt'
           />
           yolo swag
         </Custoplayer>

--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 import Custoplayer from './lib/EntryPoint';
+import { useState } from 'react';
 
 function App() {
+  const [previewTooltipId, setPreviewTooltipId] = useState('text');
+
   return (
     <MainContainer>
       <Wrapper>
@@ -13,7 +16,7 @@ function App() {
           preload='auto'
           values={{
             previewTooltip: {
-              id: 'thumbnail',
+              id: previewTooltipId,
               atlasImage:
                 'https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/thumbs.jpg',
             },
@@ -112,13 +115,19 @@ function App() {
             src='https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/spanish.vtt'
           />
           <track
-            label='bob'
             kind='metadata'
             id='custoplayer-thumbnails'
             src='https://custoplayer.nyc3.cdn.digitaloceanspaces.com/testing/thumbs.vtt'
           />
           yolo swag
         </Custoplayer>
+        <h2>Options:</h2>
+        <button
+          data-cy='changePreviewTooltipIdButton'
+          onClick={() => setPreviewTooltipId('thumbnail')}
+        >
+          Change previewTooltip to thumbnail
+        </button>
       </Wrapper>
     </MainContainer>
   );
@@ -128,6 +137,7 @@ const MainContainer = styled.main`
   background-color: #1d1d1dff;
   height: 100vh;
   width: 100vw;
+  color: white;
 `;
 
 const Wrapper = styled.div`

--- a/packages/custoplayer/src/lib/EntryPoint.tsx
+++ b/packages/custoplayer/src/lib/EntryPoint.tsx
@@ -4,7 +4,7 @@
 */
 import { EntryPointProps } from './types';
 import { Provider } from 'jotai';
-import { myScope } from '@root/lib/atoms';
+import { myScope } from './atoms';
 import Custoplayer from './Custoplayer';
 
 function EntryPoint({ values, ...rest }: EntryPointProps) {

--- a/packages/custoplayer/src/lib/atoms.ts
+++ b/packages/custoplayer/src/lib/atoms.ts
@@ -24,23 +24,6 @@ export const setVideoContainerAtom = atom(
   },
 );
 
-// Video Quality
-export const currentQualityAtom = atom(1080);
-export const possibleQualities = new Set([
-  144, 240, 360, 480, 720, 1080, 1440, 2160,
-]);
-
-export const videoQualitiesAtom = atom<videoQualitiesAtomType>({
-  2160: null,
-  1440: null,
-  1080: null,
-  720: null,
-  480: null,
-  360: null,
-  240: null,
-  144: null,
-});
-
 export const videoAttributesAtom = atom<ComponentPropsWithoutRef<'video'>>({});
 
 // Video Play State
@@ -66,13 +49,35 @@ export const formattedDurationAtom = atom((get) => {
 // Playback Speed
 export const playbackSpeedAtom = atom(1);
 
+// Preview Tooltips
+
+
 // Subtitles
 export const currentSubtitleAtom = atom<VTTCue | null>(null);
 export const subtitlesAtom = atom<Array<TextTrack> | null>(null);
 export const currentTextTrackAtom = atom<TextTrack | null>(null);
 
+// Video Quality
+export const currentQualityAtom = atom(1080);
+export const possibleQualities = new Set([
+  144, 240, 360, 480, 720, 1080, 1440, 2160,
+]);
+
+export const videoQualitiesAtom = atom<videoQualitiesAtomType>({
+  2160: null,
+  1440: null,
+  1080: null,
+  720: null,
+  480: null,
+  360: null,
+  240: null,
+  144: null,
+});
+
 // Controls Bar
 export const showControlsBarAtom = atom(false);
+
+
 
 // Video Dimensions
 export const videoDimensionsObserverAtom = atom<ResizeObserver | null>(null);
@@ -96,10 +101,13 @@ export const isProgressDraggingAtom = atom(false);
 export const progressBufferPercentAtom = atom(0);
 
 // Preview Tooltips
-export const previewTooltipWidth = 60;
-
-export const previewTooltipStrAtom = atom('00:00');
+export const previewTooltipHoveredTimeAtom = atom(0)
+export const previewTooltipStrAtom = atom((get) => {
+  return formatTime(get(previewTooltipHoveredTimeAtom));
+});
 export const previewTooltipPositionAtom = atom(0);
+export const previewTooltipThumbnailsAtom = atom<TextTrackCueList | null>(null);
+
 
 // Volume Bar
 export const volumeAtom = atom(1);

--- a/packages/custoplayer/src/lib/atoms.ts
+++ b/packages/custoplayer/src/lib/atoms.ts
@@ -51,7 +51,6 @@ export const playbackSpeedAtom = atom(1);
 
 // Preview Tooltips
 
-
 // Subtitles
 export const currentSubtitleAtom = atom<VTTCue | null>(null);
 export const subtitlesAtom = atom<Array<TextTrack> | null>(null);
@@ -77,8 +76,6 @@ export const videoQualitiesAtom = atom<videoQualitiesAtomType>({
 // Controls Bar
 export const showControlsBarAtom = atom(false);
 
-
-
 // Video Dimensions
 export const videoDimensionsObserverAtom = atom<ResizeObserver | null>(null);
 export const videoDimensionsAtom = atom<{ height: number; width: number }>({
@@ -101,13 +98,12 @@ export const isProgressDraggingAtom = atom(false);
 export const progressBufferPercentAtom = atom(0);
 
 // Preview Tooltips
-export const previewTooltipHoveredTimeAtom = atom(0)
+export const previewTooltipHoveredTimeAtom = atom(0);
 export const previewTooltipStrAtom = atom((get) => {
   return formatTime(get(previewTooltipHoveredTimeAtom));
 });
 export const previewTooltipPositionAtom = atom(0);
 export const previewTooltipThumbnailsAtom = atom<TextTrackCueList | null>(null);
-
 
 // Volume Bar
 export const volumeAtom = atom(1);

--- a/packages/custoplayer/src/lib/components/ControlsBar.tsx
+++ b/packages/custoplayer/src/lib/components/ControlsBar.tsx
@@ -71,7 +71,7 @@ function ControlsBar() {
 
   return (
     <AnimatePresence>
-      {(isProgressDragging || isVolumeDragging || isControlsBarShowing) && (
+      {(true || isVolumeDragging || isControlsBarShowing) && (
         <ControlsContainer
           className={draggableSymbol.toString()}
           variants={

--- a/packages/custoplayer/src/lib/components/ControlsBar.tsx
+++ b/packages/custoplayer/src/lib/components/ControlsBar.tsx
@@ -71,7 +71,7 @@ function ControlsBar() {
 
   return (
     <AnimatePresence>
-      {(true || isVolumeDragging || isControlsBarShowing) && (
+      {(isProgressDragging || isVolumeDragging || isControlsBarShowing) && (
         <ControlsContainer
           className={draggableSymbol.toString()}
           variants={

--- a/packages/custoplayer/src/lib/components/HTMLVideoPlayer.tsx
+++ b/packages/custoplayer/src/lib/components/HTMLVideoPlayer.tsx
@@ -18,6 +18,7 @@ import {
   playbackSpeedAtom,
   PlayState,
   playStateAtom,
+  previewTooltipThumbnailsAtom,
   progressAtom,
   progressBufferPercentAtom,
   showControlsBarAtom,
@@ -31,8 +32,7 @@ import {
 
 import { SyntheticEvent, useCallback } from 'react';
 import { getCurrentQuality, handlePlayState, throttle } from '../utils';
-
-import { useQualities, useSubtitles } from '../hooks';
+import { usePreviewThumbnails, useQualities, useSubtitles } from '../hooks';
 
 function HTMLVideoPlayer() {
   const [videoElem, setVideoElem] = useAtom(videoElemAtom, myScope);
@@ -68,6 +68,10 @@ function HTMLVideoPlayer() {
   const setCurrentSubtitle = useSetAtom(currentSubtitleAtom, myScope);
   const setCurrentTextTrack = useSetAtom(currentTextTrackAtom, myScope);
   const setVideoQualities = useSetAtom(videoQualitiesAtom, myScope);
+  const setPreviewTooltipThumbnails = useSetAtom(
+    previewTooltipThumbnailsAtom,
+    myScope,
+  );
   const isProgressDragging = useAtomValue(isProgressDraggingAtom, myScope);
   const isVolumeDragging = useAtomValue(isVolumeDraggingAtom, myScope);
   const videoAttributes = useAtomValue(videoAttributesAtom, myScope);
@@ -100,6 +104,7 @@ function HTMLVideoPlayer() {
     setCurrentSubtitle,
     setCurrentTextTrack,
   );
+  usePreviewThumbnails(videoElem, setPreviewTooltipThumbnails);
 
   const handlePlay = () => {
     setPlayState(PlayState.playing);

--- a/packages/custoplayer/src/lib/components/PlayIndicator.tsx
+++ b/packages/custoplayer/src/lib/components/PlayIndicator.tsx
@@ -103,7 +103,7 @@ const Container = styled.div`
   flex-direction: column;
 `;
 
-const IndicatorContainer = styled(motion.button) <{
+const IndicatorContainer = styled(motion.button)<{
   playButtonColor: string | undefined;
 }>`
   color: ${(props) => props.playButtonColor};

--- a/packages/custoplayer/src/lib/components/PlayIndicator.tsx
+++ b/packages/custoplayer/src/lib/components/PlayIndicator.tsx
@@ -38,7 +38,6 @@ function PlayIndicator() {
   const playState = useAtomValue(playStateAtom, myScope);
   const isSeeking = useAtomValue(isSeekingAtom, myScope);
   const items = useAtomValue(itemsAtom, myScope);
-  const videoElem = useAtomValue(videoElemAtom, myScope);
   const currentSubtitle = useAtomValue(currentSubtitleAtom, myScope);
   const isControlsShowing = useAtomValue(showControlsBarAtom, myScope);
   const playButtonItem: PlayButtonItem | undefined = findPlayButton(items);
@@ -104,7 +103,7 @@ const Container = styled.div`
   flex-direction: column;
 `;
 
-const IndicatorContainer = styled(motion.button)<{
+const IndicatorContainer = styled(motion.button) <{
   playButtonColor: string | undefined;
 }>`
   color: ${(props) => props.playButtonColor};
@@ -124,6 +123,7 @@ const SubtitleContainer = styled(motion.div)`
   background-color: black;
   margin: 1rem;
   opacity: 0.75;
+  font-size: 1.1em;
 `;
 
 export default PlayIndicator;

--- a/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
+++ b/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
@@ -79,13 +79,13 @@ function PreviewTooltips({
           {previewTooltipStr}
         </TextTooltip>
       )}
-      {data.id === 'thumbnail' && (
+      {(data.id === 'thumbnail' || data.id === "textAndThumbnail") && (
         <ImageThumbnailContainer
           data-cy='imageThumbnailContainer'
           backgroundColor={videoValues.controlsBar?.barColor}
           isVisible={(isHovered || isProgressDragging) && videoDuration > 0}
           style={{
-            transform: `translate(${previewTooltipPosition}px, -120px)`,
+            transform: `translate(${previewTooltipPosition}px, ${data.id === "thumbnail" ? "-120px" : "-135px"})`,
           }}
         >
           <ImageThumbnail
@@ -96,8 +96,11 @@ function PreviewTooltips({
             width={previewTooltipThumbnailData.w}
             backgroundImage={data.atlasImage ?? ''}
           />
+          {data.id === "textAndThumbnail" && <TimeContainer>{previewTooltipStr}</TimeContainer>}
         </ImageThumbnailContainer>
       )}
+
+
     </>
   );
 }
@@ -117,12 +120,16 @@ const TextTooltip = styled.span<{
   box-shadow: 10px 10px 20px 1px rgba(0, 0, 0, 0.25);
 `;
 
-const ImageThumbnailContainer = styled(TextTooltip)<{
+const ImageThumbnailContainer = styled(TextTooltip) <{
   isVisible: boolean;
   backgroundColor: string | undefined;
 }>`
   padding: 0.5rem;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 `;
 
 const ImageThumbnail = styled.div<{
@@ -137,6 +144,11 @@ const ImageThumbnail = styled.div<{
   background-position: ${(props) => props.backgroundPositionX}px
     ${(props) => props.backgroundPositionY}px;
   background-image: url(${(props) => props.backgroundImage});
+`;
+
+const TimeContainer = styled.div`
+  padding: 0.25rem;
+
 `;
 
 export default PreviewTooltips;

--- a/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
+++ b/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
@@ -4,10 +4,14 @@ import styled from 'styled-components';
 import {
   durationAtom,
   myScope,
+  previewTooltipHoveredTimeAtom,
   previewTooltipPositionAtom,
   previewTooltipStrAtom,
+  previewTooltipThumbnailsAtom,
   valuesAtom,
 } from '../atoms';
+import { getHoveredThumbnail } from '../utils';
+import { useEffect, useState } from 'react';
 
 interface PreviewTooltipProps {
   isHovered: boolean;
@@ -24,9 +28,43 @@ function PreviewTooltips({
     previewTooltipPositionAtom,
     myScope,
   );
+  const previewTooltipHoveredTime = useAtomValue(
+    previewTooltipHoveredTimeAtom,
+    myScope,
+  );
   const previewTooltipStr = useAtomValue(previewTooltipStrAtom, myScope);
   const videoValues = useAtomValue(valuesAtom, myScope);
+
   const videoDuration = useAtomValue(durationAtom, myScope);
+
+  const previewTooltipThumbnails = useAtomValue(
+    previewTooltipThumbnailsAtom,
+    myScope,
+  );
+  const [previewTooltipThumbnailData, setPreviewTooltipThumbnailData] =
+    useState({ x: 0, y: 0, w: 0, h: 0 });
+
+  useEffect(() => {
+    if (data.id !== 'text') {
+      const foundThumbnail = getHoveredThumbnail(
+        previewTooltipHoveredTime,
+        previewTooltipThumbnails,
+      );
+
+      if (foundThumbnail) {
+        // Add error handling here
+        const text = foundThumbnail.text;
+        const [x, y, w, h] = text.split('=')[1].split(',');
+        setPreviewTooltipThumbnailData({
+          x: parseInt(x),
+          y: parseInt(y),
+          w: parseInt(w),
+          h: parseInt(h),
+        });
+      }
+    }
+  }, [previewTooltipHoveredTime]);
+
   return (
     <>
       {data.id === 'text' && (
@@ -40,6 +78,23 @@ function PreviewTooltips({
         >
           {previewTooltipStr}
         </TextTooltip>
+      )}
+      {data.id === 'thumbnail' && (
+        <ImageThumbnailContainer
+          backgroundColor={videoValues.controlsBar?.barColor}
+          isVisible={(isHovered || isProgressDragging) && videoDuration > 0}
+          style={{
+            transform: `translate(${previewTooltipPosition}px, -120px)`,
+          }}
+        >
+          <ImageThumbnail
+            backgroundPositionX={-1 * previewTooltipThumbnailData.x}
+            backgroundPositionY={-1 * previewTooltipThumbnailData.y}
+            height={previewTooltipThumbnailData.h}
+            width={previewTooltipThumbnailData.w}
+            backgroundImage={data.atlasImage ?? ''}
+          />
+        </ImageThumbnailContainer>
       )}
     </>
   );
@@ -58,6 +113,28 @@ const TextTooltip = styled.span<{
   opacity: ${(props) => (props.isVisible ? 1 : 0)};
   transition: opacity 300ms;
   box-shadow: 10px 10px 20px 1px rgba(0, 0, 0, 0.25);
+`;
+
+const ImageThumbnailContainer = styled(TextTooltip)<{
+  isVisible: boolean;
+  backgroundColor: string | undefined;
+}>`
+  padding: 0.5rem;
+  box-sizing: border-box;
+`;
+
+const ImageThumbnail = styled.div<{
+  backgroundPositionX: number;
+  backgroundPositionY: number;
+  backgroundImage: string;
+  height: number;
+  width: number;
+}>`
+  height: ${(props) => props.height}px;
+  width: ${(props) => props.width}px;
+  background-position: ${(props) => props.backgroundPositionX}px
+    ${(props) => props.backgroundPositionY}px;
+  background-image: url(${(props) => props.backgroundImage});
 `;
 
 export default PreviewTooltips;

--- a/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
+++ b/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
@@ -79,13 +79,15 @@ function PreviewTooltips({
           {previewTooltipStr}
         </TextTooltip>
       )}
-      {(data.id === 'thumbnail' || data.id === "textAndThumbnail") && (
+      {(data.id === 'thumbnail' || data.id === 'textAndThumbnail') && (
         <ImageThumbnailContainer
           data-cy='imageThumbnailContainer'
           backgroundColor={videoValues.controlsBar?.barColor}
           isVisible={(isHovered || isProgressDragging) && videoDuration > 0}
           style={{
-            transform: `translate(${previewTooltipPosition}px, ${data.id === "thumbnail" ? "-120px" : "-135px"})`,
+            transform: `translate(${previewTooltipPosition}px, ${
+              data.id === 'thumbnail' ? '-120px' : '-135px'
+            })`,
           }}
         >
           <ImageThumbnail
@@ -96,11 +98,11 @@ function PreviewTooltips({
             width={previewTooltipThumbnailData.w}
             backgroundImage={data.atlasImage ?? ''}
           />
-          {data.id === "textAndThumbnail" && <TimeContainer>{previewTooltipStr}</TimeContainer>}
+          {data.id === 'textAndThumbnail' && (
+            <TimeContainer>{previewTooltipStr}</TimeContainer>
+          )}
         </ImageThumbnailContainer>
       )}
-
-
     </>
   );
 }
@@ -120,7 +122,7 @@ const TextTooltip = styled.span<{
   box-shadow: 10px 10px 20px 1px rgba(0, 0, 0, 0.25);
 `;
 
-const ImageThumbnailContainer = styled(TextTooltip) <{
+const ImageThumbnailContainer = styled(TextTooltip)<{
   isVisible: boolean;
   backgroundColor: string | undefined;
 }>`
@@ -148,7 +150,6 @@ const ImageThumbnail = styled.div<{
 
 const TimeContainer = styled.div`
   padding: 0.25rem;
-
 `;
 
 export default PreviewTooltips;

--- a/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
+++ b/packages/custoplayer/src/lib/components/PreviewTooltips.tsx
@@ -81,6 +81,7 @@ function PreviewTooltips({
       )}
       {data.id === 'thumbnail' && (
         <ImageThumbnailContainer
+          data-cy='imageThumbnailContainer'
           backgroundColor={videoValues.controlsBar?.barColor}
           isVisible={(isHovered || isProgressDragging) && videoDuration > 0}
           style={{
@@ -88,6 +89,7 @@ function PreviewTooltips({
           }}
         >
           <ImageThumbnail
+            data-cy='imageThumbnail'
             backgroundPositionX={-1 * previewTooltipThumbnailData.x}
             backgroundPositionY={-1 * previewTooltipThumbnailData.y}
             height={previewTooltipThumbnailData.h}
@@ -130,8 +132,8 @@ const ImageThumbnail = styled.div<{
   height: number;
   width: number;
 }>`
-  height: ${(props) => props.height}px;
-  width: ${(props) => props.width}px;
+  height: ${(props) => (props.height ? props.height : '70')}px;
+  width: ${(props) => (props.width ? props.width : '125')}px;
   background-position: ${(props) => props.backgroundPositionX}px
     ${(props) => props.backgroundPositionY}px;
   background-image: url(${(props) => props.backgroundImage});

--- a/packages/custoplayer/src/lib/components/ProgressBars/index.tsx
+++ b/packages/custoplayer/src/lib/components/ProgressBars/index.tsx
@@ -2,9 +2,10 @@ import {
   isProgressDraggingAtom,
   myScope,
   playStateAtom,
+  previewTooltipHoveredTimeAtom,
   previewTooltipPositionAtom,
-  previewTooltipStrAtom,
   progressAtom,
+  valuesAtom,
   videoContainerAtom,
   videoElemAtom,
 } from '@root/lib/atoms';
@@ -28,6 +29,9 @@ interface ProgressBarsProps {
   onTop?: boolean;
 }
 
+const previewTooltip2Height = 150;
+const previewTooltip1Height = 60;
+
 function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
   const progressBarRef = useRef<HTMLDivElement | null>(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -35,7 +39,7 @@ function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
   const videoContainer = useAtomValue(videoContainerAtom, myScope);
   const setProgress = useSetAtom(progressAtom, myScope);
   const playState = useAtomValue(playStateAtom, myScope);
-
+  const values = useAtomValue(valuesAtom, myScope);
   // Needed for remembering what play state to set after progress dragging is complete
   const [tempVideoPauseState, setTempVideoPauseState] = useState(-1);
   const [isProgressDragging, setIsProgressDragging] = useAtom(
@@ -46,8 +50,10 @@ function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
     previewTooltipPositionAtom,
     myScope,
   );
-  const setTooltipStr = useSetAtom(previewTooltipStrAtom, myScope);
-
+  const setPreviewTooltipHoveredTime = useSetAtom(
+    previewTooltipHoveredTimeAtom,
+    myScope,
+  );
   /**
   A wrapper function for handleProgressBarMouseMove that passes in the
   video container's bounding rect. It is the callback function for
@@ -64,9 +70,12 @@ function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
       progressBarRef,
       videoContainer,
       videoElem,
+      values.previewTooltip?.id === 'text'
+        ? previewTooltip1Height
+        : previewTooltip2Height,
       setProgress,
       setIsProgressDragging,
-      setTooltipStr,
+      setPreviewTooltipHoveredTime,
       setPreviewTooltipPosition,
     );
   }
@@ -109,7 +118,10 @@ function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
           progressBarRef,
           videoContainer,
           videoElem,
-          setTooltipStr,
+          values.previewTooltip?.id === 'text'
+            ? previewTooltip1Height
+            : previewTooltip2Height,
+          setPreviewTooltipHoveredTime,
           setPreviewTooltipPosition,
         )
       }

--- a/packages/custoplayer/src/lib/components/SettingsButtons.tsx
+++ b/packages/custoplayer/src/lib/components/SettingsButtons.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { useOnClickOutside } from '../hooks';
 import { SettingsButtonItem } from '../types';
-import { darkenColor, lightenColor } from '../utils';
 import SettingsMenu from './SettingsMenu';
 
 function SettingsButtons({ item }: { item: SettingsButtonItem }) {

--- a/packages/custoplayer/src/lib/types.ts
+++ b/packages/custoplayer/src/lib/types.ts
@@ -129,6 +129,8 @@ export interface ControlsBarItem {
 export interface PreviewTooltipItem {
   /** Accepts value of "text" */
   id: 'text' | 'thumbnail' | 'textAndThumbnail';
+  /** Accepts a string to the url of the image of the video */
+  atlasImage?: string;
 }
 
 export interface VolumeItem {

--- a/packages/custoplayer/src/lib/utils.tsx
+++ b/packages/custoplayer/src/lib/utils.tsx
@@ -8,11 +8,7 @@ import {
   VolumeItem,
 } from '@root/lib/types';
 import { SetStateAction, SyntheticEvent } from 'react';
-import {
-  isVolumeDraggingType,
-  possibleQualities,
-  previewTooltipWidth,
-} from '@root/lib/atoms';
+import { isVolumeDraggingType, possibleQualities } from '@root/lib/atoms';
 import Color from 'color';
 
 export const debounce = (fn: (...args: any[]) => void, ms = 300) => {
@@ -213,9 +209,10 @@ export function handleProgressBarMouseMove(
   progressBarRef: React.MutableRefObject<HTMLDivElement | null>,
   videoContainer: HTMLDivElement | null,
   videoElem: HTMLVideoElement | null,
+  previewTooltipWidth: number,
   setProgress: (update: SetStateAction<number>) => void,
   setIsProgressDragging: (update: SetStateAction<boolean>) => void,
-  setTooltipStr: (update: SetStateAction<string>) => void,
+  setPreviewTooltipHoveredTime: (update: SetStateAction<number>) => void,
   setPreviewTooltipPosition: (update: SetStateAction<number>) => void,
 ) {
   setIsProgressDragging(true);
@@ -235,7 +232,8 @@ export function handleProgressBarMouseMove(
       progressBarRef,
       videoContainer,
       videoElem,
-      setTooltipStr,
+      previewTooltipWidth,
+      setPreviewTooltipHoveredTime,
       setPreviewTooltipPosition,
     );
     const adjustedMousePos = updatedMousePos - distLeftOfProgressBar;
@@ -249,7 +247,7 @@ export function handleProgressBarMouseMove(
     if (videoElem && videoElem.duration) {
       const currentTime = videoElem.duration * ratio;
       videoElem.currentTime = currentTime;
-      setTooltipStr(formatTime(currentTime));
+      setPreviewTooltipHoveredTime(currentTime);
     }
 
     setProgress(ratio);
@@ -265,7 +263,8 @@ export function showPreviewThumbnail(
   progressBarRef: React.MutableRefObject<HTMLDivElement | null>,
   videoContainer: HTMLDivElement | null,
   videoElem: HTMLVideoElement | null,
-  setTooltipStr: (update: SetStateAction<string>) => void,
+  previewTooltipWidth: number,
+  setPreviewTooltipHoveredTime: (update: SetStateAction<number>) => void,
   setPreviewTooltipPosition: (update: SetStateAction<number>) => void,
 ) {
   if (
@@ -309,7 +308,7 @@ export function showPreviewThumbnail(
   if (videoElem && videoElem.duration) {
     const ratio = clamp(timePos / progressBarRef.current.clientWidth, 0, 1);
     const currentTime = videoElem.duration * ratio;
-    setTooltipStr(formatTime(currentTime));
+    setPreviewTooltipHoveredTime(currentTime);
   }
 }
 
@@ -487,4 +486,20 @@ export function selectSubtitleTrack(
     prev[selectedIndex].mode = 'showing';
     return prev;
   });
+}
+
+export function getHoveredThumbnail(
+  previewTooltipHoveredTime: number,
+  previewTooltipThumbnails: TextTrackCueList | null,
+) {
+  if (previewTooltipThumbnails === null) return null;
+  const previewTooltipThumbnailsArray = Array.from(
+    previewTooltipThumbnails,
+  ) as VTTCue[];
+  const hoveredThumbnail = previewTooltipThumbnailsArray.find(
+    (cue) =>
+      previewTooltipHoveredTime > cue.startTime &&
+      previewTooltipHoveredTime < cue.endTime,
+  );
+  return hoveredThumbnail ?? null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,7 +182,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.20.12", "@babel/core@^7.7.5":
+"@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.20.12", "@babel/core@^7.21.4", "@babel/core@^7.7.5":
   version "7.21.8"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.8.tgz#2a8c7f0f53d60100ba4c32470ba0281c92aa9aa4"
   integrity sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==
@@ -1052,14 +1052,14 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.18.6"
 
-"@babel/plugin-transform-react-jsx-self@^7.16.7":
+"@babel/plugin-transform-react-jsx-self@^7.16.7", "@babel/plugin-transform-react-jsx-self@^7.21.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.21.0.tgz#ec98d4a9baafc5a1eb398da4cf94afbb40254a54"
   integrity sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-react-jsx-source@^7.16.7":
+"@babel/plugin-transform-react-jsx-source@^7.16.7", "@babel/plugin-transform-react-jsx-source@^7.19.6":
   version "7.19.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz#88578ae8331e5887e8ce28e4c9dc83fb29da0b86"
   integrity sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==
@@ -2022,10 +2022,120 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@esbuild/android-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz#bafb75234a5d3d1b690e7c2956a599345e84a2fd"
+  integrity sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==
+
+"@esbuild/android-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.19.tgz#5898f7832c2298bc7d0ab53701c57beb74d78b4d"
+  integrity sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==
+
+"@esbuild/android-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.19.tgz#658368ef92067866d95fb268719f98f363d13ae1"
+  integrity sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==
+
+"@esbuild/darwin-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz#584c34c5991b95d4d48d333300b1a4e2ff7be276"
+  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
+
+"@esbuild/darwin-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz#7751d236dfe6ce136cce343dce69f52d76b7f6cb"
+  integrity sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==
+
+"@esbuild/freebsd-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz#cacd171665dd1d500f45c167d50c6b7e539d5fd2"
+  integrity sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==
+
+"@esbuild/freebsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz#0769456eee2a08b8d925d7c00b79e861cb3162e4"
+  integrity sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==
+
+"@esbuild/linux-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz#38e162ecb723862c6be1c27d6389f48960b68edb"
+  integrity sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==
+
+"@esbuild/linux-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz#1a2cd399c50040184a805174a6d89097d9d1559a"
+  integrity sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==
+
+"@esbuild/linux-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz#e28c25266b036ce1cabca3c30155222841dc035a"
+  integrity sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==
+
 "@esbuild/linux-loong64@0.14.54":
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
   integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
+
+"@esbuild/linux-loong64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz#0f887b8bb3f90658d1a0117283e55dbd4c9dcf72"
+  integrity sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==
+
+"@esbuild/linux-mips64el@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz#f5d2a0b8047ea9a5d9f592a178ea054053a70289"
+  integrity sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==
+
+"@esbuild/linux-ppc64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz#876590e3acbd9fa7f57a2c7d86f83717dbbac8c7"
+  integrity sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==
+
+"@esbuild/linux-riscv64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz#7f49373df463cd9f41dc34f9b2262d771688bf09"
+  integrity sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==
+
+"@esbuild/linux-s390x@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz#e2afd1afcaf63afe2c7d9ceacd28ec57c77f8829"
+  integrity sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==
+
+"@esbuild/linux-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz#8a0e9738b1635f0c53389e515ae83826dec22aa4"
+  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
+
+"@esbuild/netbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz#c29fb2453c6b7ddef9a35e2c18b37bda1ae5c462"
+  integrity sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==
+
+"@esbuild/openbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz#95e75a391403cb10297280d524d66ce04c920691"
+  integrity sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==
+
+"@esbuild/sunos-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz#722eaf057b83c2575937d3ffe5aeb16540da7273"
+  integrity sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==
+
+"@esbuild/win32-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz#9aa9dc074399288bdcdd283443e9aeb6b9552b6f"
+  integrity sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==
+
+"@esbuild/win32-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz#95ad43c62ad62485e210f6299c7b2571e48d2b03"
+  integrity sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==
+
+"@esbuild/win32-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
+  integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -2970,14 +3080,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@17.0.14":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.14.tgz#c8f917156b652ddf807711f5becbd2ab018dea9f"
-  integrity sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^18.0.10":
+"@types/react-dom@^18.0.10", "@types/react-dom@^18.0.11":
   version "18.2.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.4.tgz#13f25bfbf4e404d26f62ac6e406591451acba9e0"
   integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
@@ -3019,19 +3122,19 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.43":
-  version "17.0.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
-  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+"@types/react@^18.0.27":
+  version "18.2.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.5.tgz#f9403e1113b12b53f7edcdd9a900c10dd4b49a59"
+  integrity sha512-RuoMedzJ5AOh23Dvws13LU9jpZHIc/k90AgmK7CecAYeWmSr3553L4u5rk4sWAPBuQosfT7HmTfG4Rg5o4nGEA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.0.27":
-  version "18.2.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.5.tgz#f9403e1113b12b53f7edcdd9a900c10dd4b49a59"
-  integrity sha512-RuoMedzJ5AOh23Dvws13LU9jpZHIc/k90AgmK7CecAYeWmSr3553L4u5rk4sWAPBuQosfT7HmTfG4Rg5o4nGEA==
+"@types/react@^18.0.28":
+  version "18.2.6"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.6.tgz#5cd53ee0d30ffc193b159d3516c8c8ad2f19d571"
+  integrity sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3152,6 +3255,22 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@^5.57.1":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.6.tgz#a350faef1baa1e961698240f922d8de1761a9e2b"
+  integrity sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==
+  dependencies:
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/type-utils" "5.59.6"
+    "@typescript-eslint/utils" "5.59.6"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/parser@^5.10.0", "@typescript-eslint/parser@^5.54.0":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.2.tgz#c2c443247901d95865b9f77332d9eee7c55655e8"
@@ -3162,6 +3281,16 @@
     "@typescript-eslint/typescript-estree" "5.59.2"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@^5.57.1":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.6.tgz#bd36f71f5a529f828e20b627078d3ed6738dbb40"
+  integrity sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/typescript-estree" "5.59.6"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz#f699fe936ee4e2c996d14f0fdd3a7da5ba7b9a4c"
@@ -3169,6 +3298,14 @@
   dependencies:
     "@typescript-eslint/types" "5.59.2"
     "@typescript-eslint/visitor-keys" "5.59.2"
+
+"@typescript-eslint/scope-manager@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.6.tgz#d43a3687aa4433868527cfe797eb267c6be35f19"
+  integrity sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==
+  dependencies:
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/visitor-keys" "5.59.6"
 
 "@typescript-eslint/type-utils@5.59.2":
   version "5.59.2"
@@ -3180,10 +3317,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.6.tgz#37c51d2ae36127d8b81f32a0a4d2efae19277c48"
+  integrity sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.59.6"
+    "@typescript-eslint/utils" "5.59.6"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.2.tgz#b511d2b9847fe277c5cb002a2318bd329ef4f655"
   integrity sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==
+
+"@typescript-eslint/types@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.6.tgz#5a6557a772af044afe890d77c6a07e8c23c2460b"
+  integrity sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==
 
 "@typescript-eslint/typescript-estree@5.59.2":
   version "5.59.2"
@@ -3192,6 +3344,19 @@
   dependencies:
     "@typescript-eslint/types" "5.59.2"
     "@typescript-eslint/visitor-keys" "5.59.2"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.6.tgz#2fb80522687bd3825504925ea7e1b8de7bb6251b"
+  integrity sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/visitor-keys" "5.59.6"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -3212,12 +3377,34 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.6.tgz#82960fe23788113fc3b1f9d4663d6773b7907839"
+  integrity sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/typescript-estree" "5.59.6"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.59.2":
   version "5.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz#37a419dc2723a3eacbf722512b86d6caf7d3b750"
   integrity sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==
   dependencies:
     "@typescript-eslint/types" "5.59.2"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.6.tgz#673fccabf28943847d0c8e9e8d008e3ada7be6bb"
+  integrity sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==
+  dependencies:
+    "@typescript-eslint/types" "5.59.6"
     eslint-visitor-keys "^3.3.0"
 
 "@vitejs/plugin-react@1.3.2", "@vitejs/plugin-react@^1.0.8":
@@ -3233,6 +3420,16 @@
     "@rollup/pluginutils" "^4.2.1"
     react-refresh "^0.13.0"
     resolve "^1.22.0"
+
+"@vitejs/plugin-react@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.0.0.tgz#46d1c37c507447d10467be1c111595174555ef28"
+  integrity sha512-HX0XzMjL3hhOYm+0s95pb0Z7F8O81G7joUHgfDd/9J/ZZf5k4xX6QAMFkKsHFxaHlf6X7GD7+XuaZ66ULiJuhQ==
+  dependencies:
+    "@babel/core" "^7.21.4"
+    "@babel/plugin-transform-react-jsx-self" "^7.21.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.19.6"
+    react-refresh "^0.14.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5485,6 +5682,34 @@ esbuild@^0.14.27:
     esbuild-windows-64 "0.14.54"
     esbuild-windows-arm64 "0.14.54"
 
+esbuild@^0.17.5:
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
+  integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.17.19"
+    "@esbuild/android-arm64" "0.17.19"
+    "@esbuild/android-x64" "0.17.19"
+    "@esbuild/darwin-arm64" "0.17.19"
+    "@esbuild/darwin-x64" "0.17.19"
+    "@esbuild/freebsd-arm64" "0.17.19"
+    "@esbuild/freebsd-x64" "0.17.19"
+    "@esbuild/linux-arm" "0.17.19"
+    "@esbuild/linux-arm64" "0.17.19"
+    "@esbuild/linux-ia32" "0.17.19"
+    "@esbuild/linux-loong64" "0.17.19"
+    "@esbuild/linux-mips64el" "0.17.19"
+    "@esbuild/linux-ppc64" "0.17.19"
+    "@esbuild/linux-riscv64" "0.17.19"
+    "@esbuild/linux-s390x" "0.17.19"
+    "@esbuild/linux-x64" "0.17.19"
+    "@esbuild/netbsd-x64" "0.17.19"
+    "@esbuild/openbsd-x64" "0.17.19"
+    "@esbuild/sunos-x64" "0.17.19"
+    "@esbuild/win32-arm64" "0.17.19"
+    "@esbuild/win32-ia32" "0.17.19"
+    "@esbuild/win32-x64" "0.17.19"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -5564,6 +5789,11 @@ eslint-plugin-react-hooks@^4.6.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
+eslint-plugin-react-refresh@^0.3.4:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.3.5.tgz#0121e3f05f940250d3544bfaeff52e1c6adf4117"
+  integrity sha512-61qNIsc7fo9Pp/mju0J83kzvLm0Bsayu7OQSLEoJxLDCBjIIyb87bkzufoOvdDxLkSlMfkF7UxomC4+eztUBSA==
+
 eslint-plugin-react@^7.32.2:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"
@@ -5611,7 +5841,7 @@ eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.7.0:
+eslint@^8.38.0, eslint@^8.7.0:
   version "8.40.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
   integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==
@@ -7982,7 +8212,7 @@ multimatch@^4.0.0:
     arrify "^2.0.1"
     minimatch "^3.0.4"
 
-nanoid@^3.3.4:
+nanoid@^3.3.4, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
@@ -8816,6 +9046,15 @@ postcss@^8.3.11, postcss@^8.4.13, postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@^8.4.23:
+  version "8.4.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
+  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -9187,6 +9426,11 @@ react-refresh@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz#cbd01a4482a177a5da8d44c9755ebb1f26d5a1c1"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
+
+react-refresh@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
 react-router-config@^5.1.1:
   version "5.1.1"
@@ -9569,10 +9813,10 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^2.59.0:
-  version "2.79.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+rollup@^3.21.0:
+  version "3.21.8"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.21.8.tgz#fc768008fe2c953f18210370fd70fe1ffff59e2c"
+  integrity sha512-SSFV2T2fWtQ/vvBip85u2Nr0GNKireabH9d7nXswBg+XSH+jbVDSYptRAEbCEsquhs503rpPA9POYAp0/Jhasw==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -10568,15 +10812,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
 typescript@^4.5.4, typescript@^4.9.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.0.2:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 typescript@~4.8.4:
   version "4.8.4"
@@ -10917,18 +11161,6 @@ vite-plugin-mdx@^3.5.6:
     resolve "^1.20.0"
     unified "^9.2.1"
 
-vite@2.9.13:
-  version "2.9.13"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.13.tgz#859cb5d4c316c0d8c6ec9866045c0f7858ca6abc"
-  integrity sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==
-  dependencies:
-    esbuild "^0.14.27"
-    postcss "^8.4.13"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 vite@^2.9.13:
   version "2.9.15"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.15.tgz#2858dd5b2be26aa394a283e62324281892546f0b"
@@ -10938,6 +11170,17 @@ vite@^2.9.13:
     postcss "^8.4.13"
     resolve "^1.22.0"
     rollup ">=2.59.0 <2.78.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vite@^4.3.2:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.7.tgz#04f98ab0f4689490545b2f6fa0515e95072bb298"
+  integrity sha512-MTIFpbIm9v7Hh5b0wSBgkcWzSBz7SAa6K/cBTwS4kUiQJfQLFlZZRJRQgqunCVzhTPCk674tW+0Qaqh3Q00dBg==
+  dependencies:
+    esbuild "^0.17.5"
+    postcss "^8.4.23"
+    rollup "^3.21.0"
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
* Added the ability for users to set previewTooltip id property to `thumbnail` or `textAndThumbnail`

* To configure previewTooltipThumbnails you need to:
  1. add the atlas image url to the `atlasImage` property of the previewTooltip object
  2. Add a track with a link with the url to the thumbnail image vtt file. This track should have an id of `custoplayer-thumbnails`

* The atlasImage and the thumbnail vtt file can be generated from: https://github.com/Etesam913/Custoplayer-Thumbnail-Generator

