### PR TITLE
Fixes scrubber overflow when scrubber is transparent, but scrubberBorder is not

### DIFF
--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -57,7 +57,6 @@ function App() {
             item4: {
               id: 'progressBar1',
               progressColor: '#6a994e',
-              barColor: 'white',
             },
             item5: {
               id: 'duration',

--- a/packages/custoplayer/src/lib/components/ControlsBar.tsx
+++ b/packages/custoplayer/src/lib/components/ControlsBar.tsx
@@ -93,10 +93,12 @@ function ControlsBar() {
       </ItemContainer>
     );
   }
+  const shouldShowControlsBar =
+    isProgressDragging || isVolumeDragging || isControlsBarShowing;
 
   return (
     <AnimatePresence>
-      {(isProgressDragging || isVolumeDragging || isControlsBarShowing) && (
+      {shouldShowControlsBar && (
         <ControlsContainer
           className={draggableSymbol.toString()}
           variants={

--- a/packages/custoplayer/src/lib/components/ProgressBars/index.tsx
+++ b/packages/custoplayer/src/lib/components/ProgressBars/index.tsx
@@ -93,9 +93,12 @@ function ProgressBars({ item, onTop = false }: ProgressBarsProps) {
   );
 
   const shouldAnimate = isHovered || isProgressDragging;
-  const hasScrubber =
-    item.scrubberColor !== 'transparent' &&
-    item.scrubberBorderColor !== 'transparent';
+  const hasScrubber = !(
+    item.scrubberColor === 'transparent' &&
+    (item.scrubberBorderColor === 'transparent' ||
+      item.scrubberBorderColor === 'none' ||
+      item.scrubberBorderColor === undefined)
+  );
 
   return (
     <ProgressBarContainer


### PR DESCRIPTION
## Resolves #84 

* When the scrubberColor is transparent, but the scrubberBorder exists, it should be treated as if there is a scrubber. Progress should not have a min-width of 16px
* Put controlsBar bool condition in separate variable to improve readability