### PR TITLE
Fix settings menu focus bug

### DIFF
--- a/packages/custoplayer/package.json
+++ b/packages/custoplayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custoplayer",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/custoplayer/src/lib/components/SettingsMenu/MenuButton.tsx
+++ b/packages/custoplayer/src/lib/components/SettingsMenu/MenuButton.tsx
@@ -8,14 +8,14 @@ function traverseListUsingKeys(e: React.KeyboardEvent<HTMLButtonElement>) {
     if (previousListItem) {
       const previousButton =
         previousListItem.firstElementChild as HTMLButtonElement;
-      previousButton.focus();
+      if (previousButton) previousButton.focus();
     }
     // Reached top of list
     else {
       const lastListItem = listItem?.parentElement?.lastElementChild;
       if (lastListItem) {
         const lastButton = lastListItem.firstElementChild as HTMLButtonElement;
-        lastButton.focus();
+        if (lastButton) lastButton.focus();
       }
     }
   } else if (e.key === 'ArrowDown') {
@@ -23,7 +23,7 @@ function traverseListUsingKeys(e: React.KeyboardEvent<HTMLButtonElement>) {
     const nextListItem = listItem?.nextElementSibling as HTMLElement;
     if (nextListItem) {
       const nextButton = nextListItem.firstElementChild as HTMLButtonElement;
-      nextButton.focus();
+      if (nextButton) nextButton.focus();
     }
     // Reached bottom of list
     else {
@@ -31,7 +31,7 @@ function traverseListUsingKeys(e: React.KeyboardEvent<HTMLButtonElement>) {
       if (firstListItem) {
         const firstButton =
           firstListItem.firstElementChild as HTMLButtonElement;
-        firstButton.focus();
+        if (firstButton) firstButton.focus();
       }
     }
   }

--- a/packages/custoplayer/src/lib/presets.tsx
+++ b/packages/custoplayer/src/lib/presets.tsx
@@ -242,9 +242,7 @@ export const testing: CustoplayerValues = {
     settingsMenuColor: '#386641',
     settingsMenuOrientation: 'left',
     options: {
-      subtitles: true,
       playbackSpeed: [0.25, 0.5, 1, 1.25, 1.5, 1.75, 2],
-      quality: true,
     },
   },
   item7: {

--- a/packages/custoplayer/src/lib/presets.tsx
+++ b/packages/custoplayer/src/lib/presets.tsx
@@ -242,7 +242,9 @@ export const testing: CustoplayerValues = {
     settingsMenuColor: '#386641',
     settingsMenuOrientation: 'left',
     options: {
+      subtitles: true,
       playbackSpeed: [0.25, 0.5, 1, 1.25, 1.5, 1.75, 2],
+      quality: true,
     },
   },
   item7: {

--- a/packages/custoplayer/src/lib/utils.tsx
+++ b/packages/custoplayer/src/lib/utils.tsx
@@ -101,6 +101,7 @@ export function handleKeyPress(
     e.key === 'ArrowDown'
   ) {
     e.preventDefault();
+
     if (video !== null && focusedItem !== null) {
       if (focusedItem.startsWith('volumeBar')) {
         let newVolume = video.volume;
@@ -124,12 +125,14 @@ export function handleKeyPress(
         video.volume = clamp(newVolume, 0, 1);
       } else {
         let newTime = video.currentTime;
-        if (e.key === 'ArrowLeft') {
-          newTime -= 5;
-        } else if (e.key === 'ArrowRight') {
-          newTime += 5;
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          if (e.key === 'ArrowLeft') {
+            newTime -= 5;
+          } else if (e.key === 'ArrowRight') {
+            newTime += 5;
+          }
+          video.currentTime = clamp(newTime, 0, video.duration);
         }
-        video.currentTime = clamp(newTime, 0, video.duration);
       }
     }
   }


### PR DESCRIPTION
* using up and down arrow keys when the settings menu was open could sometimes return a null reference to the next button
  * Added a check to see if the next or previous sibling is null
* Using up and down arrow keys would update current time as the if statement condition was not strict enough
  * Added an additional if statement to fix this.   