### PR TITLE
Fix `alwaysVisible` on typo

### DIFF
--- a/packages/custoplayer/package.json
+++ b/packages/custoplayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custoplayer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/custoplayer/src/App.tsx
+++ b/packages/custoplayer/src/App.tsx
@@ -32,7 +32,6 @@ function App() {
           preload='auto'
           values={{
             ...testing,
-
             previewTooltip: {
               id: previewTooltipId,
               atlasImage:

--- a/packages/custoplayer/src/lib/components/ControlsBar.tsx
+++ b/packages/custoplayer/src/lib/components/ControlsBar.tsx
@@ -103,8 +103,8 @@ function ControlsBar() {
       </ItemContainer>
     );
   }
-  const shouldShowControlsBar = videoValues.controlsBar?.alyawsVisible
-    ? videoValues.controlsBar?.alyawsVisible
+  const shouldShowControlsBar = videoValues.controlsBar?.alwaysVisible
+    ? videoValues.controlsBar?.alwaysVisible
     : isProgressDragging || isVolumeDragging || isControlsBarShowing;
 
   return (

--- a/packages/custoplayer/src/lib/components/ProgressBars/ProgressBar1.tsx
+++ b/packages/custoplayer/src/lib/components/ProgressBars/ProgressBar1.tsx
@@ -131,11 +131,12 @@ const Scrubber = styled(motion.div)<{
   scrubberColor: string | undefined;
   scrubberBorderColor: string | undefined;
 }>`
-  height: 0.75rem;
-  width: 0.75rem;
+  height: 1rem;
+  width: 1rem;
   background-color: ${(props) => props.scrubberColor ?? 'white'};
   position: absolute;
   border-radius: 50rem;
+  box-sizing: border-box;
   border: ${(props) =>
     props.scrubberBorderColor !== undefined
       ? '2px solid ' + props.scrubberBorderColor

--- a/packages/custoplayer/src/lib/components/VolumeBars.tsx
+++ b/packages/custoplayer/src/lib/components/VolumeBars.tsx
@@ -208,8 +208,9 @@ const Scrubber = styled(motion.div)<{
   scrubberColor: string | undefined;
   scrubberBorderColor: string | undefined;
 }>`
-  height: 0.75rem;
-  width: 0.75rem;
+  height: 0.9rem;
+  width: 0.9rem;
+  box-sizing: border-box;
   background-color: ${(props) => props.scrubberColor ?? 'white'};
   position: absolute;
   border-radius: 50rem;

--- a/packages/custoplayer/src/lib/types.ts
+++ b/packages/custoplayer/src/lib/types.ts
@@ -126,7 +126,7 @@ export interface ControlsBarItem {
   barColor?: string;
   /** Changes how the controlsBar animates. Accepts values of "opacity" and "movement". Setting animate to "opacity" will do a simple fade in animation. Setting animate to "movement" will animate the controls bar from bottom -> up*/
   animate?: 'opacity' | 'movement';
-  alyawsVisible?: boolean;
+  alwaysVisible?: boolean;
 }
 
 export interface PreviewTooltipItem {


### PR DESCRIPTION
## Resolves #104 
* The property used to be misnamed, this could lead to confusion
* The typo was fixed

* Also fixed a padding bug with the scrubbers by setting `box-sizing: border-box` on them.